### PR TITLE
Add support for dnsmasq 2.86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ Makefile.in
 /config.log
 /config.status
 /configure
+/dnsmasq/stamp-dnsmasq-dir
+/dnsmasq/undefined_sys_hack.c
 /hello/undefined_sys_hack.c
 /initrd
 /install-sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ clean-local:
 	rm -rf initrd supermin.d
 	-find -name config.cache -delete
 
-DIST_SUBDIRS = hello memcached redis
+DIST_SUBDIRS = dnsmasq hello memcached redis
 
 #----------------------------------------------------------------------
 # Build libgcc and static libstdc++.

--- a/Makefile.am
+++ b/Makefile.am
@@ -170,9 +170,6 @@ stamp-glibc-configure:
 	    target_alias=x86_64-ukl
 	touch $@
 
-undefined_sys_hack.o: undefined_sys_hack.c
-	gcc -o $@ -c -ggdb -O2 -fno-omit-frame-pointer -mno-red-zone -mcmodel=kernel -fno-pic $^
-
 #----------------------------------------------------------------------
 # Build Linux kernel linked with UKL.a
 
@@ -207,7 +204,7 @@ endif
 #----------------------------------------------------------------------
 # Compile the program.
 
-UKL.a: undefined_sys_hack.o $(PROGRAM)/UKL.a
+UKL.a: $(PROGRAM)/UKL.a
 	cp $< $@
 
 $(PROGRAM)/UKL.a: $(CRT_OBJS) $(LIBC_OBJS)

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,7 @@ AC_MSG_RESULT([$ENABLE_AFTERSPACE])
 dnl Produce output files.
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile \
+                 dnsmasq/Makefile \
                  hello/Makefile \
                  memcached/Makefile \
                  redis/Makefile])

--- a/dnsmasq/Makefile.am
+++ b/dnsmasq/Makefile.am
@@ -1,0 +1,82 @@
+# Unikernel Linux
+# Copyright (C) 2018-2022 Red Hat Inc., Boston University,
+# Ali Raza, Tommy Unger, Eric Munson, Richard W.M. Jones.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+CLEANFILES = \
+	*~ *.o *.a \
+	stamp-dnsmasq-dir
+
+clean-local:
+	-cd dnsmasq && $(MAKE) clean
+
+distclean-local:
+	rm -rf dnsmasq
+
+noinst_DATA = UKL.a
+
+# Libraries built in the top build directory.
+CRT_STARTS  = $(abs_top_builddir)/crt1.o $(abs_top_builddir)/crti.o \
+	      $(abs_top_builddir)/crtbeginT.o
+CRT_ENDS    = $(abs_top_builddir)/crtend.o $(abs_top_builddir)/crtn.o
+C_LIB       = $(abs_top_builddir)/libc.a
+PTHREAD_LIB = $(abs_top_builddir)/libpthread.a
+RT_LIB      = $(abs_top_builddir)/librt.a
+MATH_LIB    = $(abs_top_builddir)/libm.a
+GCC_LIBS    = $(abs_top_builddir)/libgcc.a $(abs_top_builddir)/libgcc_eh.a
+
+AM_CFLAGS   = -ggdb -mno-red-zone -mcmodel=kernel -static
+
+UKL.a: dnsmasq.o undefined_sys_hack.o
+	rm -f $@
+	ar cr UKL.a $^
+	objcopy --prefix-symbols=ukl_ $@
+	objcopy --redefine-syms=$(top_srcdir)/redef_sym_names $@
+
+dnsmasq.o: stamp-dnsmasq-dir
+	rm -f $@
+	$(MAKE) -C dnsmasq clean
+	$(MAKE) -C dnsmasq all CFLAGS="-O2 $(AM_CFLAGS)"
+	rm dnsmasq/src/dnsmasq
+	ld -r -o $@ -allow-multiple-definition \
+	    $(CRT_STARTS) \
+	    dnsmasq/src/*.o \
+	    --start-group \
+	    --whole-archive \
+	    $(MATH_LIB) $(RT_LIB) $(PTHREAD_LIB) $(C_LIB) \
+	    --no-whole-archive \
+	    $(GCC_LIBS) \
+	    --end-group \
+	    $(CRT_ENDS)
+
+# Check out a local copy of dnsmasq (XXX submodules!).
+stamp-dnsmasq-dir:
+	rm -f $@
+	if ! test -d dnsmasq; then \
+	    git clone http://thekelleys.org.uk/git/dnsmasq.git && \
+	    cd dnsmasq && \
+	    git checkout -b 2.86 cac9ca38f62437c65464f58fc54342c7f294c40b; \
+	fi
+	touch $@
+
+undefined_sys_hack.c: $(top_builddir)/undefined_sys_hack.c
+	cp $< $@
+
+# automake doesn't add this rule unless we were to specify a C program
+# to compile, which we don't want to do because of the very special
+# linking requirements.
+.c.o:
+	$(CC) $(CFLAGS) $(AM_CFLAGS) -c $< -o $@


### PR DESCRIPTION
This adds support for compiling dnsmasq.

It doesn't quite work out of the box yet.  The reason is that as soon as it starts it attempts to read `/dev/urandom` which doesn't exist.  As discussed on email I think we need to start populating `/dev` in the appliance.

More broadly I think we need some kind of mechanism for passing custom files and command line arguments "per program".  I'll have a think about how to do this nicely.