### PR TITLE
Use clean instead of mrproper for cleaning linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ CLEANFILES = \
 clean-local:
 	-cd glibc-build && $(MAKE) clean
 	-cd libgcc-build && $(MAKE) clean
-	-cd linux && $(MAKE) mrproper
+	-cd linux && $(MAKE) clean
 	rm -rf initrd supermin.d
 	-find -name config.cache -delete
 


### PR DESCRIPTION
When we use make mrproper in the linux directory, this deletes the
.config file that was put in place by the configure script. This means
that we have to rerun the configure after any make clean.  Instead,
change the clean-local target to use make clean for the linux dir.

Signed-off-by: Eric B Munson <munsoner@bu.edu>