### PR TITLE
Utilize Docker cache when building initrd

### DIFF
--- a/initrd/create-initrd.sh
+++ b/initrd/create-initrd.sh
@@ -2,18 +2,11 @@
 
 set -x
 
-docker pull fedora:36
-CONTAINER=init-builder
-docker stop $CONTAINER
-docker rm -f $CONTAINER
 ABSINIT=`readlink -f .`
-docker run --rm --privileged --name=${CONTAINER} -v ${ABSINIT}:/src -dit fedora:36 /bin/bash
-docker exec -it $CONTAINER dnf -y update
-docker exec -it $CONTAINER dnf -y install sed elfutils-libelf-devel bc hostname perl dropbear \
-        msr-tools wget dnf-plugins-core bzip2 curl xz cpio shadow-utils procps-ng iproute \
-	pciutils net-tools openssh-server
+docker build ukl-base -t ukl-base:latest
+CONTAINER=$(docker run --rm --privileged -v ${ABSINIT}:/src -dit ukl-base:latest /bin/bash)
 docker exec -w /src/ -it $CONTAINER rm -rf ukl-initrd
 docker exec -w /src/ -it $CONTAINER ./set-passwd.sh
 docker exec -w /src/ -it $CONTAINER ./buildinitrd.sh ukl-initrd
 docker exec -w /src/ -it $CONTAINER rm -rf ukl-initrd
-docker stop $CONTAINER
+docker stop $CONTAINER >/dev/null 2>&1 &

--- a/initrd/ukl-base/Dockerfile
+++ b/initrd/ukl-base/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:36
+
+RUN dnf update -y
+RUN dnf -y install sed elfutils-libelf-devel bc hostname perl dropbear \
+        msr-tools wget dnf-plugins-core bzip2 curl xz cpio shadow-utils procps-ng iproute \
+	pciutils net-tools openssh-server


### PR DESCRIPTION
Docker will cache the filesystem diff of each step in a Dockerfile. We can use this to avoid re-downloading all of our packages every time we want to reconstruct the initrd.

Note that Docker will use the cached diff even if newer versions of the packages are available. To force redownload, run `docker rmi ukl-base` before running `make`.